### PR TITLE
fix: 修复 Python 3.14 下 jwc.cli 启动失败（ics/tatsu 兼容）

### DIFF
--- a/src/jwc/schedule.py
+++ b/src/jwc/schedule.py
@@ -1,6 +1,41 @@
 from dataclasses import dataclass
 from typing import Self
 from typing_extensions import Hashable
+import collections
+import collections.abc
+
+# Compatibility shim for ics 0.7.x on modern Python/TatSu combinations.
+# - TatSu 4.x needs collections.Mapping on Python 3.10+
+# - TatSu 5.x removed generic_main and rejects old parser setting buffer_class
+if not hasattr(collections, "Mapping"):
+    collections.Mapping = collections.abc.Mapping  # type: ignore[attr-defined]
+
+try:
+    from tatsu import util as _tatsu_util  # pyright: ignore[reportMissingTypeStubs]
+
+    if not hasattr(_tatsu_util, "generic_main"):
+        def _generic_main(*_args, **_kwargs):
+            raise RuntimeError("tatsu.util.generic_main is unavailable in this TatSu version.")
+
+        _tatsu_util.generic_main = _generic_main  # type: ignore[attr-defined]
+
+    try:
+        from tatsu.util.configs import Config as _tatsu_config  # pyright: ignore[reportMissingTypeStubs]
+
+        if not getattr(_tatsu_config, "_jwc_ics_compat_patched", False):
+            _original_check_unknowns = _tatsu_config._check_unknowns
+
+            def _check_unknowns_compat(self, **settings):
+                settings.pop("buffer_class", None)
+                return _original_check_unknowns(self, **settings)
+
+            _tatsu_config._check_unknowns = _check_unknowns_compat
+            _tatsu_config._jwc_ics_compat_patched = True
+    except Exception:
+        pass
+except Exception:
+    pass
+
 import ics  # pyright: ignore[reportMissingTypeStubs]
 import datetime
 from jwc.schedule_preset_trules import TransformationResults


### PR DESCRIPTION
## 背景

在 Python 3.14 环境下运行 python -m jwc.cli 会启动失败。
根因是 ics==0.7.2 与 TatSu 5.x 的兼容问题（generic_main、buffer_class），以及 collections.Mapping 兼容差异。

## 修改内容

- 修改文件：src/jwc/schedule.py
- 在 import ics 前增加兼容层：
- 兼容 collections.Mapping（映射到 collections.abc.Mapping）
- 当 tatsu.util.generic_main 缺失时提供补丁
- 对 tatsu.util.configs.Config._check_unknowns 做兼容处理，忽略 buffer_class

## 验证结果

已在源码模式验证通过：

- PYTHONPATH=src python -m jwc.cli --help
- PYTHONPATH=src python -m jwc.cli to-ics --help

## 影响范围

- 仅影响 jwc 启动阶段对 ics 的导入兼容
- 不涉及业务逻辑变更（课表解析/导出逻辑未改）

## 备注

当前仍会出现 pydantic_yaml 在 Python 3.14 下的 warning，但不影响 CLI 启动和子命令加载。
